### PR TITLE
Remove node-json-db requirement, fixes #50

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -5,14 +5,10 @@ const {app, shell} = require('electron');
 const electronLocalshortcut = require('electron-localshortcut');
 const ipc = require('electron').ipcMain;
 const Configstore = require('configstore');
-const JsonDB = require('node-json-db');
 const tray = require('./tray');
 const appMenu = require('./menu');
 const link = require ('./link_helper');
 const {linkIsInternal} = link;
-
-const db = new JsonDB("domain", true, true);
-const data = db.getData("/");
 
 // adds debug features like hotkeys for triggering dev tools and reload
 require('electron-debug')();
@@ -32,8 +28,8 @@ let targetLink;
 const targetUrl = 'file://' + path.join(__dirname, '../renderer', 'index.html');
 
 function checkWindowURL() {
-	if (data["domain"] !== undefined) {
-		return data["domain"]
+	if (conf.get("domain") !== undefined) {
+		return conf.get("domain")
 	}
 	return targetLink
 }
@@ -206,6 +202,12 @@ app.on('ready', () => {
 });
 
 ipc.on('new-domain', function (e, domain) {
+  conf.set('domain', domain);
 	mainWindow.loadURL(domain);
 	targetLink = domain;
 });
+
+ipc.on('get-domain', function(e, domain) {
+  e.returnValue = conf.get("domain");
+});
+

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -208,6 +208,6 @@ ipc.on('new-domain', function (e, domain) {
 });
 
 ipc.on('get-domain', function(e, domain) {
-  e.returnValue = conf.get("domain");
+  e.returnValue = conf.get("domain") || 'example.zulipchat.com';
 });
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -1,13 +1,11 @@
 window.onload = function getURL() {
 	const request = require('request');
-	const JsonDB = require('node-json-db');
 	const ipcRenderer = require('electron').ipcRenderer;
 	const dialogs = require('dialogs')()
-    const db = new JsonDB("domain", true, true);
-    const data = db.getData("/");
 
-    if (data["domain"] !== undefined) {
-        window.location.href = data["domain"];
+    const domain = ipcRenderer.sendSync('get-domain');
+    if (domain !== null) {
+        window.location.href = domain;
     } else {
 
         dialogs.prompt('Enter the URL for your Zulip server', function(url) {
@@ -17,7 +15,6 @@ window.onload = function getURL() {
 
         	request(checkURL, function (error, response, body) {
         		if (!error && response.statusCode !== 404) {
-        			    db.push("/domain", newurl);
         			    ipcRenderer.send('new-domain', newurl);
         			    window.location.href = newurl ;
         		}
@@ -31,7 +28,7 @@ window.onload = function getURL() {
 
 const getInput = document.getElementsByTagName('input')[0];
 
-getInput.setAttribute('placeholder', 'zulip.example.com'); // add placeholder
+getInput.setAttribute('placeholder', 'example.zulipchat.com'); // add placeholder
 getInput.setAttribute('spellcheck', 'false');	// no spellcheck for form	
 
 }

--- a/app/renderer/js/pref.js
+++ b/app/renderer/js/pref.js
@@ -12,8 +12,6 @@ function addDomain() {
 
         const request = require('request');
         const ipcRenderer = require('electron').ipcRenderer;
-        const JsonDB = require('node-json-db');
-        const db = new JsonDB('domain', true, true);
         document.getElementById('main').innerHTML = 'checking...'
         document.getElementById('pic').style.display ='block';
 
@@ -28,7 +26,6 @@ function addDomain() {
                 document.getElementById('pic').style.display ='none';
                 document.getElementById('main').innerHTML = 'Add'
                 document.getElementById('urladded').innerHTML = newDomain + '  Added';
-                db.push('/domain', domain);
                 ipcRenderer.send('new-domain', domain);
             }
             else {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "test": "xo",
     "start": "electron .",
-    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --all"
+    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --all",
+    "build-osx": "electron-packager . --out=dist --platform=darwin --arch=x64 --app-version=$npm_package_version --asar --overwrite"
   },
   "keywords": [
     "Zulip",
@@ -30,7 +31,6 @@
     "electron-debug": "^1.0.0",
     "electron-dl": "^0.2.0",
     "electron-localshortcut": "^0.6.1",
-    "node-json-db": "^0.7.2",
     "request": "^2.74.0",
     "simple-spellchecker": "^0.9.0",
     "wurl": "^2.1.0"


### PR DESCRIPTION
Seems that electron doesn't play nice with node-json-db.
Might be a filesystem access thing.

I have no idea what i'm doing, but now I have a nice shiny Zulip.app in ~/Applications that works, so hooray!