### PR TITLE
Use the standard method to get the electron app location

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -6,7 +6,7 @@ describe('application launch', function () {
 
   beforeEach(function () {
     this.app = new Application({
-      path: __dirname + '/../node_modules/.bin/electron',
+      path: require('electron'),
       args: [__dirname + '/../app/main/index.js']
     })
     return this.app.start()


### PR DESCRIPTION
When running "npm run test" under Windows, the tests failed to run as there was a general failure to launch the electron application. This was due to the gulpfile.js specifying the node_modules/.bin/electron file directly.

As per the guidance at https://github.com/electron-userland/electron-prebuilt programmatic usage acquires the path to electron by require('electron'). This change now results in a success test execution of the project on my Windows system.

Tested Zulip-Desktop 0.3.1 (based upon e12ad6e) on Windows 7 Enteprise SP1