### PR TITLE
Restrict internal links to the same host only, not all hosts in a domain

### DIFF
--- a/app/main/link-helper.js
+++ b/app/main/link-helper.js
@@ -2,8 +2,8 @@ const wurl = require('wurl');
 
 // Check link if it's internal/external
 function linkIsInternal(currentUrl, newUrl) {
-	const currentDomain = wurl('domain', currentUrl);
-	const newDomain = wurl('domain', newUrl);
+	const currentDomain = wurl('hostname', currentUrl);
+	const newDomain = wurl('hostname', newUrl);
 	return currentDomain === newDomain;
 }
 


### PR DESCRIPTION
The Zulip deployment guide indicates that a Zulip service is hosted with a particular host name and not across a whole domain. The logic for handling internal links should respect this otherwise links to other distinct services hosted under the same domain will be loaded by the app and not in a separate browser window.

Example: chat-server.example.com (Zulip service) and bug-tracker.example.com (a separate bug tracking service). A link to https://bug-tracker.example.com sent in a Zulip message will, if navigated to via zulip-electron, result in the bug tracker page being loaded in the application.

Note: I do not have an account on the public Zulip instance to verify this behavior there, this is an issue I noticed on a private deployment and have verified this fixes the issue on that deployment.

Tested Zulip-Desktop 0.3.1 (based upon e12ad6e) on Windows 7 Enteprise SP1