### PR TITLE
Setup for spectron on Travis CI Linux runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 - npm install
 
 script:
-- npm run test
+- npm run travis

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "gulp test && xo",
     "dev": "gulp dev",
     "build:osx": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --icon=app/resources/Icon.icns --overwrite --platform=darwin --arch=x64",
-    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --all"
+    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --all",
+    "travis": "cd ./scripts && ./travis-build-test.sh"
   },
   "keywords": [
     "Zulip",

--- a/scripts/travis-build-test.sh
+++ b/scripts/travis-build-test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  export DISPLAY=:99.0
+  sh -e /etc/init.d/xvfb start
+  sleep 3
+fi
+
+npm run test


### PR DESCRIPTION
Invoke test runs via Travis CI using a separate shell script that ensures the a suitable frame buffer is available on Linux to run chromedriver against

Example Run: https://travis-ci.org/steele/zulip-electron/builds/159046422

Tested Zulip-Desktop 0.3.1 (based upon 2d43ce0) on Windows 7 Enteprise SP1