### PR TITLE
Add caching of dependencies for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,9 @@ before_install:
 - npm install -g gulp
 - npm install
 
+cache:
+  directories:
+    - node_modules
+
 script:
 - npm run travis


### PR DESCRIPTION
Based upon https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/

Tested Zulip-Desktop 0.3.2 (based upon 30f44d2) on Windows 7 Enterprise SP1