### PR TITLE
Use the actual version number in About page

### DIFF
--- a/app/renderer/about.html
+++ b/app/renderer/about.html
@@ -7,12 +7,16 @@
 	<body>
 	<div class="about">
 		<center><img src="../resources/zulip.png"></center>
-		<center><p class="detail"> Version : 0.0.1 </p>
+		<center><p class="detail" id="version"> Version : ?.?.? </p>
 		<center><p class="detail"> License : Apache </p>
 		<center><p class="detail"> Maintainer : Zulip </p>
 		<p class="left"><a class="bug" onclick="linkInBrowser()" href="#">Found bug?</a></p>
 	</div>
 	<script>
+
+	const app = require('electron').remote.app;
+	const version_tag = document.getElementById('version');
+	version_tag.innerHTML = ' Version : ' + app.getVersion() + ' ';
 
 	function linkInBrowser(event) {
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ],
     "ignore": [
       "tests/*.js"
-     ],
+    ],
     "envs": [
       "node",
       "browser",


### PR DESCRIPTION
A small detail I noticed in passing.

Tested Zulip-Desktop 0.3.2 (based upon a72bcca) on Windows 7 Enterprise SP1
Also https://travis-ci.org/steele/zulip-electron/builds/162215126