### PR TITLE
Fix issue #112 for displaying Keyboard shortcuts

### DIFF
--- a/app/main/preload.js
+++ b/app/main/preload.js
@@ -45,13 +45,14 @@ ipcRenderer.on('log-out', () => {
 
 ipcRenderer.on('shortcut', () => {
 	// create the menu for the below
-	const node = document.querySelector('a[data-overlay-trigger=keyboard-shortcuts]')
-	//additional check
-	if (node.text.trim().toLowerCase() === "keyboard shortcuts")
+	const node = document.querySelector('a[data-overlay-trigger=keyboard-shortcuts]');
+	// additional check
+	if (node.text.trim().toLowerCase() === 'keyboard shortcuts') {
 		node.click();
-	else // atleast click the dropdown
+	} else {
+		// atleast click the dropdown
 		document.querySelector('.dropdown-toggle').click();
-	
+	}
 });
 
 // To prevent failing this script on linux we need to load it after the document loaded

--- a/app/main/preload.js
+++ b/app/main/preload.js
@@ -45,10 +45,13 @@ ipcRenderer.on('log-out', () => {
 
 ipcRenderer.on('shortcut', () => {
 	// create the menu for the below
-	document.querySelector('.dropdown-toggle').click();
-
-	const nodes = document.querySelectorAll('.dropdown-menu li:nth-child(4) a');
-	nodes[nodes.length - 1].click();
+	const node = document.querySelector('a[data-overlay-trigger=keyboard-shortcuts]')
+	//additional check
+	if (node.text.trim().toLowerCase() === "keyboard shortcuts")
+		node.click();
+	else // atleast click the dropdown
+		document.querySelector('.dropdown-toggle').click();
+	
 });
 
 // To prevent failing this script on linux we need to load it after the document loaded


### PR DESCRIPTION
Fixes #112 to show Keyboard shortcuts correctly when 'shortcut' action is sent from sendAction() instead of showing Administrator settings

- `Tested on Operating System:`
OSX Yosemite 10.10.5
- `Zulip Desktop version`
1.4.7