### PR TITLE
Fixes Issue #124

### DIFF
--- a/app/main/domain.js
+++ b/app/main/domain.js
@@ -1,6 +1,4 @@
-const {
-	app
-} = require('electron').remote;
+const {app} = require('electron').remote;
 const ipcRenderer = require('electron').ipcRenderer;
 const JsonDB = require('node-json-db');
 const request = require('request');

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -3,13 +3,9 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const electron = require('electron');
-const {
-	app
-} = require('electron');
+const {app} = require('electron');
 const ipc = require('electron').ipcMain;
-const {
-	dialog
-} = require('electron');
+const {dialog} = require('electron');
 const https = require('https');
 const http = require('http');
 const electronLocalshortcut = require('electron-localshortcut');
@@ -18,13 +14,8 @@ const JsonDB = require('node-json-db');
 const isDev = require('electron-is-dev');
 const tray = require('./tray');
 const appMenu = require('./menu');
-const {
-	linkIsInternal,
-	skipImages
-} = require('./link-helper');
-const {
-	appUpdater
-} = require('./autoupdater');
+const {linkIsInternal,skipImages} = require('./link-helper');
+const {appUpdater} = require('./autoupdater');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 const data = db.getData('/');

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -62,7 +62,7 @@ const targetURL = function () {
 function server_error(targetURL) {
 	if (targetURL.indexOf('localhost:') < 0 && data.domain) {
 		var req = https.request(targetURL + '/static/audio/zulip.ogg', (res) => {
-			console.log('Server statusCode:', res.statusCode);
+			console.log('Server StatusCode:', res.statusCode);
 			console.log('You are connected to:', res.req._headers.host);
 			if (res.statusCode >= 500 && res.statusCode <= 599) {
 				return dialog.showErrorBox('SERVER IS DOWN!', 'We are getting a ' + res.statusCode + ' error status from the server ' + res.req._headers.host + '. Please try again after some time or you may switch server.')
@@ -77,7 +77,7 @@ function server_error(targetURL) {
 		req.end();
 	} else if (data.domain) {
 		var req = http.request(targetURL + '/static/audio/zulip.ogg', (res) => {
-			console.log('statusCode:', res.statusCode);
+			console.log('Server StatusCode:', res.statusCode);
 			console.log('You are connected to:', res.req._headers.host);
 
 		});
@@ -326,6 +326,7 @@ ipc.on('new-domain', (e, domain) => {
 		mainWindow.show();
 	} else {
 		mainWindow.loadURL(domain);
+		server_error(domain);
 	}
 	targetLink = domain;
 });

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -3,19 +3,28 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const electron = require('electron');
-const {app} = require('electron');
+const {
+	app
+} = require('electron');
 const ipc = require('electron').ipcMain;
-const {dialog} = require('electron');
+const {
+	dialog
+} = require('electron');
+const https = require('https');
+const http = require('http');
 const electronLocalshortcut = require('electron-localshortcut');
 const Configstore = require('configstore');
 const JsonDB = require('node-json-db');
 const isDev = require('electron-is-dev');
 const tray = require('./tray');
 const appMenu = require('./menu');
-const {linkIsInternal, skipImages} = require('./link-helper');
-const {appUpdater} = require('./autoupdater');
-const https = require('https');
-const http = require('http');
+const {
+	linkIsInternal,
+	skipImages
+} = require('./link-helper');
+const {
+	appUpdater
+} = require('./autoupdater');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 const data = db.getData('/');
@@ -58,40 +67,30 @@ const targetURL = function () {
 	return data.domain;
 };
 
-
-function server_error(targetURL) {
+function serverError(targetURL) {
 	if (targetURL.indexOf('localhost:') < 0 && data.domain) {
-		var req = https.request(targetURL + '/static/audio/zulip.ogg', (res) => {
+		const req = https.request(targetURL + '/static/audio/zulip.ogg', res => {
 			console.log('Server StatusCode:', res.statusCode);
 			console.log('You are connected to:', res.req._headers.host);
 			if (res.statusCode >= 500 && res.statusCode <= 599) {
-				return dialog.showErrorBox('SERVER IS DOWN!', 'We are getting a ' + res.statusCode + ' error status from the server ' + res.req._headers.host + '. Please try again after some time or you may switch server.')
+				return dialog.showErrorBox('SERVER IS DOWN!', 'We are getting a ' + res.statusCode + ' error status from the server ' + res.req._headers.host + '. Please try again after some time or you may switch server.');
 			}
-
 		});
-
-		req.on('error', (e) => {
+		req.on('error', e => {
 			console.error(e);
-
 		});
 		req.end();
 	} else if (data.domain) {
-		var req = http.request(targetURL + '/static/audio/zulip.ogg', (res) => {
+		const req = http.request(targetURL + '/static/audio/zulip.ogg', res => {
 			console.log('Server StatusCode:', res.statusCode);
 			console.log('You are connected to:', res.req._headers.host);
-
 		});
-
-		req.on('error', (e) => {
+		req.on('error', e => {
 			console.error(e);
-
 		});
 		req.end();
 	}
-
-
 }
-
 
 function checkConnectivity() {
 	return dialog.showMessageBox({
@@ -192,12 +191,11 @@ function createMainWindow() {
 		win.show();
 	});
 
-         server_error(targetURL());
+	serverError(targetURL());
 
-	win.loadURL(targetURL(),
-		{
-			userAgent: isUserAgent + ' ' + win.webContents.getUserAgent()
-		});
+	win.loadURL(targetURL(), {
+		userAgent: isUserAgent + ' ' + win.webContents.getUserAgent()
+	});
 
 	win.on('closed', onClosed);
 	win.setTitle('Zulip');
@@ -326,7 +324,7 @@ ipc.on('new-domain', (e, domain) => {
 		mainWindow.show();
 	} else {
 		mainWindow.loadURL(domain);
-		server_error(domain);
+		serverError(domain);
 	}
 	targetLink = domain;
 });

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -14,7 +14,7 @@ const JsonDB = require('node-json-db');
 const isDev = require('electron-is-dev');
 const tray = require('./tray');
 const appMenu = require('./menu');
-const {linkIsInternal,skipImages} = require('./link-helper');
+const {linkIsInternal, skipImages} = require('./link-helper');
 const {appUpdater} = require('./autoupdater');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);

--- a/app/main/preload.js
+++ b/app/main/preload.js
@@ -3,12 +3,12 @@ const ipcRenderer = require('electron').ipcRenderer;
 const {webFrame} = require('electron');
 const {spellChecker} = require('./spellchecker');
 
-const _setImmediate = setImmediate
-const _clearImmediate = clearImmediate
+const _setImmediate = setImmediate;
+const _clearImmediate = clearImmediate;
 process.once('loaded', () => {
-  global.setImmediate = _setImmediate
-  global.clearImmediate = _clearImmediate
-})
+	global.setImmediate = _setImmediate;
+	global.clearImmediate = _clearImmediate;
+});
 
 // enable swipe back/forward navigation on macOS
 require('./macos-swipe-navigation.js').register();

--- a/app/main/preload.js
+++ b/app/main/preload.js
@@ -3,6 +3,13 @@ const ipcRenderer = require('electron').ipcRenderer;
 const {webFrame} = require('electron');
 const {spellChecker} = require('./spellchecker');
 
+const _setImmediate = setImmediate
+const _clearImmediate = clearImmediate
+process.once('loaded', () => {
+  global.setImmediate = _setImmediate
+  global.clearImmediate = _clearImmediate
+})
+
 // enable swipe back/forward navigation on macOS
 require('./macos-swipe-navigation.js').register();
 

--- a/app/main/windowmanager.js
+++ b/app/main/windowmanager.js
@@ -82,7 +82,4 @@ function about() {
 	});
 }
 
-exports = module.exports = {
-	addDomain,
-	about
-};
+exports = module.exports = {addDomain,about};

--- a/app/main/windowmanager.js
+++ b/app/main/windowmanager.js
@@ -82,4 +82,4 @@ function about() {
 	});
 }
 
-exports = module.exports = {addDomain,about};
+exports = module.exports = {addDomain, about};

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.8",
   "description": "Zulip Desktop App",
   "license": "Apache-2.0",
-  "email":"<svnitakash@gmail.com>",
+  "email": "<svnitakash@gmail.com>",
   "copyright": "©2017 Kandra Labs, Inc.",
   "author": {
     "name": "Akash Nimare",
@@ -27,15 +27,16 @@
     "InstantMessaging"
   ],
   "dependencies": {
-    "electron-is-dev": "0.1.2",
-    "electron-updater": "1.7.1",
-    "electron-log": "1.3.0",
     "configstore": "2.1.0",
     "electron-debug": "1.1.0",
+    "electron-is-dev": "0.1.2",
     "electron-localshortcut": "1.0.0",
+    "electron-log": "1.3.0",
+    "electron-spellchecker": "1.0.4",
+    "electron-updater": "1.7.1",
+    "https": "^1.0.0",
     "node-json-db": "0.7.3",
     "request": "2.79.0",
-    "electron-spellchecker": "1.0.4",
     "wurl": "2.1.0"
   }
 }

--- a/app/renderer/js/pref.js
+++ b/app/renderer/js/pref.js
@@ -1,8 +1,6 @@
 'use strict';
 // eslint-disable-next-line import/no-extraneous-dependencies
-const {
-	remote
-} = require('electron');
+const {remote} = require('electron');
 
 const prefWindow = remote.getCurrentWindow();
 

--- a/app/renderer/pref.html
+++ b/app/renderer/pref.html
@@ -9,7 +9,7 @@
 		<div class="form">
 			<form onsubmit="prefDomain(); return false">
 				<input id="url" type="text" placeholder="Server URL">
-				<button type="submit" id="main" value="Submit" onclick="prefDomain();">
+				<button type="submit" id="main" value="Submit">
 				Switch</button>
 			</form>
 			<p id="urladded"><p>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app/main",
   "description": "Zulip Desktop App",
   "license": "Apache-2.0",
-  "email":"<svnitakash@gmail.com>",
+  "email": "<svnitakash@gmail.com>",
   "copyright": "©2016 Kandra Labs, Inc.",
   "author": {
     "name": "Akash Nimare",
@@ -39,14 +39,17 @@
     "mac": {
       "category": "public.app-category.productivity"
     },
-    "linux" : {
+    "linux": {
       "synopsis": "Zulip Desktop App",
       "category": "",
       "packageCategory": "GNOME;GTK;Network;InstantMessaging",
       "description": "Zulip Desktop Client for Linux",
-      "target" : ["deb", "AppImage"],
-      "version" : "0.5.8",
-      "title" : "Zulip",
+      "target": [
+        "deb",
+        "AppImage"
+      ],
+      "version": "0.5.8",
+      "title": "Zulip",
       "license": "Apache-2.0",
       "maintainer": "Akash Nimare <svnitakash@gmail.com>"
     },
@@ -79,12 +82,12 @@
     }
   },
   "keywords": [
-  	"Zulip",
-  	"Group Chat app",
-  	"electron-app",
-  	"electron",
-  	"Desktop app",
-  	"InstantMessaging"
+    "Zulip",
+    "Group Chat app",
+    "electron-app",
+    "electron",
+    "Desktop app",
+    "InstantMessaging"
   ],
   "devDependencies": {
     "assert": "^1.4.1",
@@ -110,7 +113,7 @@
           "no-warning-comments": 0,
           "no-else-return": 0,
           "import/no-unresolved": 0,
-          "import/no-extraneous-dependencies":0
+          "import/no-extraneous-dependencies": 0
         }
       }
     ],
@@ -123,5 +126,8 @@
       "browser",
       "mocha"
     ]
+  },
+  "dependencies": {
+    "https": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,6 +128,5 @@
     ]
   },
   "dependencies": {
-    "https": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,5 @@
       "browser",
       "mocha"
     ]
-  },
-  "dependencies": {
   }
 }


### PR DESCRIPTION
There was no support for handling server 5XX error, This PR fixes issue #124 .
Also sometimes setImmediate Reference Error occurs
![setimmediate_error](https://cloud.githubusercontent.com/assets/13533873/24070207/ad6e7a32-0bde-11e7-9fb0-0398a840d0de.png)

I have added the removed Node global symbols back to the global scope when node integration is turned off.
This fixes the setImmediate error.
Separate commits for addressing separate part of the issue.