### PR TITLE
FIxes #126   Self-signed certificate issue

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -67,7 +67,14 @@ function serverError(targetURL) {
 			}
 		});
 		req.on('error', e => {
-			console.error(e);
+		 if (e.toString().indexOf('Error: self signed certificate') >= 0) {
+			 var url = targetURL.replace(/^https?:\/\//, '');
+			 console.log('Server StatusCode:', 200);
+			 console.log('You are connected to:', url);
+		 } else {
+		 	console.error(e);
+		 }
+
 		});
 		req.end();
 	} else if (data.domain) {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -3,9 +3,9 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const electron = require('electron');
-const { app } = require('electron');
+const {app} = require('electron');
 const ipc = require('electron').ipcMain;
-const { dialog } = require('electron');
+const {dialog} = require('electron');
 const https = require('https');
 const http = require('http');
 const electronLocalshortcut = require('electron-localshortcut');
@@ -13,8 +13,8 @@ const Configstore = require('electron-config');
 const JsonDB = require('node-json-db');
 const isDev = require('electron-is-dev');
 const appMenu = require('./menu');
-const { linkIsInternal, skipImages } = require('./link-helper');
-const { appUpdater } = require('./autoupdater');
+const {linkIsInternal, skipImages} = require('./link-helper');
+const {appUpdater} = require('./autoupdater');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 const data = db.getData('/');
@@ -67,14 +67,13 @@ function serverError(targetURL) {
 			}
 		});
 		req.on('error', e => {
-		 if (e.toString().indexOf('Error: self signed certificate') >= 0) {
-			 var url = targetURL.replace(/^https?:\/\//, '');
-			 console.log('Server StatusCode:', 200);
-			 console.log('You are connected to:', url);
-		 } else {
-		 	console.error(e);
-		 }
-
+			if (e.toString().indexOf('Error: self signed certificate') >= 0) {
+				const url = targetURL.replace(/^https?:\/\//, '');
+				console.log('Server StatusCode:', 200);
+				console.log('You are connected to:', url);
+			} else {
+				console.error(e);
+			}
 		});
 		req.end();
 	} else if (data.domain) {
@@ -256,30 +255,29 @@ function createMainWindow() {
 
 // For self-signed certificate
 ipc.on('certificate-err', (e, domain) => {
-	var detail = `URL: ${domain} \n Error: Self-Signed Certificate`;
-	dialog.showMessageBox( mainWindow, {
-							 title: 'Certificate error',
-							 message: `Do you trust certificate from ${domain}?`,
-							 detail: detail,
-							 type: 'warning',
-							 buttons: [
-									 'Yes',
-									 'No'
-							 ],
-							 cancelId: 1
-					 }, (response) => {
-							 if (response === 0) {
-								 db.push("/certifiedURL", [{domain:domain}], false);
-								 db.push('/domain', domain);
-								 mainWindow.loadURL(domain);
-							 }
-
-  });
+	const detail = `URL: ${domain} \n Error: Self-Signed Certificate`;
+	dialog.showMessageBox(mainWindow, {
+		title: 'Certificate error',
+		message: `Do you trust certificate from ${domain}?`,
+		// eslint-disable-next-line object-shorthand
+		detail: detail,
+		type: 'warning',
+		buttons: ['Yes', 'No'],
+		cancelId: 1
+		// eslint-disable-next-line object-shorthand
+	}, response => {
+		if (response === 0) {
+			// eslint-disable-next-line object-shorthand
+			db.push('/certifiedURL', [{domain: domain}], false);
+			db.push('/domain', domain);
+			mainWindow.loadURL(domain);
+		}
+	});
 });
-
+// eslint-disable-next-line max-params
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
-		event.preventDefault();
-		callback(true);
+	event.preventDefault();
+	callback(true);
 });
 
 app.on('window-all-closed', () => {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -268,7 +268,6 @@ ipc.on('certificate-err', (e, domain) => {
 	}, response => {
 		if (response === 0) {
 			// eslint-disable-next-line object-shorthand
-			db.push('/certifiedURL', [{domain: domain}], false);
 			db.push('/domain', domain);
 			mainWindow.loadURL(domain);
 		}

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -248,10 +248,31 @@ function createMainWindow() {
 // app.commandLine.appendSwitch('ignore-certificate-errors', 'true');
 
 // For self-signed certificate
+ipc.on('certificate-err', (e, domain) => {
+	var detail = `URL: ${domain} \n Error: Self-Signed Certificate`;
+	dialog.showMessageBox( mainWindow, {
+							 title: 'Certificate error',
+							 message: `Do you trust certificate from ${domain}?`,
+							 detail: detail,
+							 type: 'warning',
+							 buttons: [
+									 'Yes',
+									 'No'
+							 ],
+							 cancelId: 1
+					 }, (response) => {
+							 if (response === 0) {
+								 db.push("/certifiedURL", [{domain:domain}], false);
+								 db.push('/domain', domain);
+								 mainWindow.loadURL(domain);
+							 }
+
+  });
+});
+
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
-	console.log("warning: ", url, " certificate-error");
-		event.preventDefault()
-		callback(true)
+		event.preventDefault();
+		callback(true);
 });
 
 app.on('window-all-closed', () => {

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -20,8 +20,7 @@
                             Zulip Server URL
                         </label>
                         <input type="text" id="url"  autofocus="autofocus" spellcheck="false" placeholder="Server URL">
-                        <button type="submit" id="main" class="btn-primary btn-large" value="Submit"
-                                onclick="addDomain();">Connect</button>
+                        <button type="submit" id="main" class="btn-primary btn-large" value="Submit">Connect</button>
                         <p id="error"></p>
                     </form>
                 </div>

--- a/app/renderer/js/domain.js
+++ b/app/renderer/js/domain.js
@@ -4,6 +4,27 @@ const JsonDB = require('node-json-db');
 const request = require('request');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
+const data = db.getData('/');
+
+if(!data.certifiedURL) {
+		db.push("/certifiedURL",[]);
+}
+
+let URL_List = db.getData('/certifiedURL');
+let URL_Length = URL_List.length;
+
+
+const checkURL = domain => {
+
+	for ( var i = 0; i < URL_Length; i++) {
+		if (URL_List[i].domain === domain);
+		return true;
+		break;
+	}
+	return false;
+
+};
+
 
 window.addDomain = function () {
 	const el = sel => {
@@ -59,6 +80,15 @@ window.addDomain = function () {
 					$el.main.innerHTML = 'Connect';
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
+				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
+ 						if(checkURL(domain)) {
+							$el.main.innerHTML = 'Connect';
+						  db.push('/domain', domain);
+						  ipcRenderer.send('new-domain', domain);
+					 } else {
+						 $el.main.innerHTML = 'Connect';
+   					 ipcRenderer.send('certificate-err', domain);
+					 }
 				} else {
 					$el.main.innerHTML = 'Connect';
 					displayError('Not a valid Zulip server');

--- a/app/renderer/js/domain.js
+++ b/app/renderer/js/domain.js
@@ -6,25 +6,21 @@ const request = require('request');
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 const data = db.getData('/');
 
-if(!data.certifiedURL) {
-		db.push("/certifiedURL",[]);
+if (!data.certifiedURL) {
+	db.push('/certifiedURL', []);
 }
 
-let URL_List = db.getData('/certifiedURL');
-let URL_Length = URL_List.length;
-
+const UrlList = db.getData('/certifiedURL');
+const UrlLength = UrlList.length;
 
 const checkURL = domain => {
-
-	for ( var i = 0; i < URL_Length; i++) {
-		if (URL_List[i].domain === domain);
-		return true;
-		break;
+	for (let i = 0; i < UrlLength; i++) {
+		if (UrlList[i].domain === domain) {
+			return true;
+		}
 	}
 	return false;
-
 };
-
 
 window.addDomain = function () {
 	const el = sel => {
@@ -81,14 +77,14 @@ window.addDomain = function () {
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
 				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
- 						if(checkURL(domain)) {
-							$el.main.innerHTML = 'Connect';
-						  db.push('/domain', domain);
-						  ipcRenderer.send('new-domain', domain);
-					 } else {
-						 $el.main.innerHTML = 'Connect';
-   					 ipcRenderer.send('certificate-err', domain);
-					 }
+					if (checkURL(domain)) {
+						$el.main.innerHTML = 'Connect';
+						db.push('/domain', domain);
+						ipcRenderer.send('new-domain', domain);
+					} else {
+						$el.main.innerHTML = 'Connect';
+						ipcRenderer.send('certificate-err', domain);
+					}
 				} else {
 					$el.main.innerHTML = 'Connect';
 					displayError('Not a valid Zulip server');

--- a/app/renderer/js/domain.js
+++ b/app/renderer/js/domain.js
@@ -4,23 +4,6 @@ const JsonDB = require('node-json-db');
 const request = require('request');
 
 const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
-const data = db.getData('/');
-
-if (!data.certifiedURL) {
-	db.push('/certifiedURL', []);
-}
-
-const UrlList = db.getData('/certifiedURL');
-const UrlLength = UrlList.length;
-
-const checkURL = domain => {
-	for (let i = 0; i < UrlLength; i++) {
-		if (UrlList[i].domain === domain) {
-			return true;
-		}
-	}
-	return false;
-};
 
 window.addDomain = function () {
 	const el = sel => {
@@ -77,14 +60,8 @@ window.addDomain = function () {
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
 				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
-					if (checkURL(domain)) {
-						$el.main.innerHTML = 'Connect';
-						db.push('/domain', domain);
-						ipcRenderer.send('new-domain', domain);
-					} else {
-						$el.main.innerHTML = 'Connect';
-						ipcRenderer.send('certificate-err', domain);
-					}
+					$el.main.innerHTML = 'Connect';
+					ipcRenderer.send('certificate-err', domain);
 				} else {
 					$el.main.innerHTML = 'Connect';
 					displayError('Not a valid Zulip server');

--- a/app/renderer/js/pref.js
+++ b/app/renderer/js/pref.js
@@ -24,19 +24,6 @@ window.prefDomain = function () {
 
 	const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 
-	const UrlList = db.getData('/certifiedURL');
-
-	const UrlLength = UrlList.length;
-
-	const checkURL = domain => {
-		for (let i = 0; i < UrlLength; i++) {
-			if (UrlList[i].domain === domain) {
-				return true;
-			}
-		}
-		return false;
-	};
-
 	let newDomain = document.getElementById('url').value;
 	newDomain = newDomain.replace(/^https?:\/\//, '');
 	newDomain = newDomain.replace(/^http?:\/\//, '');
@@ -69,15 +56,9 @@ window.prefDomain = function () {
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
 				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
-					if (checkURL(domain)) {
-						document.getElementById('main').innerHTML = 'Switch';
-						document.getElementById('urladded').innerHTML = 'Switched to ' + newDomain;
-						db.push('/domain', domain);
-						ipcRenderer.send('new-domain', domain);
-					} else {
-						document.getElementById('main').innerHTML = 'Switch';
-						ipcRenderer.send('certificate-err', domain);
-					}
+					document.getElementById('main').innerHTML = 'Switch';
+					ipcRenderer.send('certificate-err', domain);
+					document.getElementById('urladded').innerHTML = 'Switched to ' + newDomain;
 				} else {
 					document.getElementById('main').innerHTML = 'Switch';
 					document.getElementById('urladded').innerHTML = 'Not a valid Zulip Server.';

--- a/app/renderer/js/pref.js
+++ b/app/renderer/js/pref.js
@@ -26,6 +26,21 @@ window.prefDomain = function () {
 
 	const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 
+	let URL_List = db.getData('/certifiedURL');
+
+	let URL_Length = URL_List.length;
+
+	const checkURL = domain => {
+
+		for ( var i = 0; i < URL_Length; i++) {
+			if (URL_List[i].domain === domain);
+			return true;
+			break;
+		}
+		return false;
+
+	};
+
 	let newDomain = document.getElementById('url').value;
 	newDomain = newDomain.replace(/^https?:\/\//, '');
 	newDomain = newDomain.replace(/^http?:\/\//, '');
@@ -57,7 +72,19 @@ window.prefDomain = function () {
 					document.getElementById('urladded').innerHTML = 'Switched to ' + newDomain;
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
-				} else {
+				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
+					if(checkURL(domain)) {
+						document.getElementById('main').innerHTML = 'Switch';
+						document.getElementById('urladded').innerHTML = 'Switched to ' + newDomain;
+						db.push('/domain', domain);
+						ipcRenderer.send('new-domain', domain);
+				 } else {
+					 document.getElementById('main').innerHTML = 'Switch';
+					 ipcRenderer.send('certificate-err', domain);
+				 }
+
+				}
+				 else {
 					document.getElementById('main').innerHTML = 'Switch';
 					document.getElementById('urladded').innerHTML = 'Not a valid Zulip Server.';
 				}

--- a/app/renderer/js/pref.js
+++ b/app/renderer/js/pref.js
@@ -20,25 +20,21 @@ window.prefDomain = function () {
 	const ipcRenderer = require('electron').ipcRenderer;
 	const JsonDB = require('node-json-db');
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const {
-		app
-	} = require('electron').remote;
+	const {app} = require('electron').remote;
 
 	const db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
 
-	let URL_List = db.getData('/certifiedURL');
+	const UrlList = db.getData('/certifiedURL');
 
-	let URL_Length = URL_List.length;
+	const UrlLength = UrlList.length;
 
 	const checkURL = domain => {
-
-		for ( var i = 0; i < URL_Length; i++) {
-			if (URL_List[i].domain === domain);
-			return true;
-			break;
+		for (let i = 0; i < UrlLength; i++) {
+			if (UrlList[i].domain === domain) {
+				return true;
+			}
 		}
 		return false;
-
 	};
 
 	let newDomain = document.getElementById('url').value;
@@ -73,18 +69,16 @@ window.prefDomain = function () {
 					db.push('/domain', domain);
 					ipcRenderer.send('new-domain', domain);
 				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
-					if(checkURL(domain)) {
+					if (checkURL(domain)) {
 						document.getElementById('main').innerHTML = 'Switch';
 						document.getElementById('urladded').innerHTML = 'Switched to ' + newDomain;
 						db.push('/domain', domain);
 						ipcRenderer.send('new-domain', domain);
-				 } else {
-					 document.getElementById('main').innerHTML = 'Switch';
-					 ipcRenderer.send('certificate-err', domain);
-				 }
-
-				}
-				 else {
+					} else {
+						document.getElementById('main').innerHTML = 'Switch';
+						ipcRenderer.send('certificate-err', domain);
+					}
+				} else {
 					document.getElementById('main').innerHTML = 'Switch';
 					document.getElementById('urladded').innerHTML = 'Not a valid Zulip Server.';
 				}


### PR DESCRIPTION
Currently our app doesn't support servers with self-signed certificates.

This PR fixes that.
When a user tries to connect a server with a self-signed certificate, a dialog box appears asking for permission. If permission is granted the app loads the server. Also, that server is added to the list of `CertifiedURL`  in app's backend, so the user doesn't face the dialog box in future if he tries to connect the same server but only initially once.

![dialogbox](https://cloud.githubusercontent.com/assets/13533873/25277023/9dd64266-26ba-11e7-9939-b8f5853495cb.png)

Any suggestions on improving this PR are welcome :smile: 
