### PR TITLE
Updated installation instruction for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ multi-account, auto-updates etc.
 ```sh
 $ sudo apt-get install build-essential libxext-dev libxtst-dev libxkbfile-dev
 ```
+
 * If you're on Windows, you'll need to install following package as administrator:
 ```sh
 C:\Windows\system32> npm install -g windows-build-tools
 ```
+Note:
+> Computers running on Windows OS may encounter problems when installing the Electron app. As Windows does not come bundled with a C++ compiler, which is needed in NodeJS, the command prompt may throw up an error which states that node-gyp rebuild fails on your system. Hence it is advised a further prerequisite (for Windows users) is to download Visual Studio Community 2015 which contains a C++ compiler using the above command.
+
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zulip Desktop Client 
+# Zulip Desktop Client
 [![Build Status](https://travis-ci.org/zulip/zulip-electron.svg?branch=master)](https://travis-ci.org/zulip/zulip-electron)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/zulip/zulip-electron?branch=master&svg=true)](https://ci.appveyor.com/project/akashnimare/zulip-electron/branch/master)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
@@ -12,7 +12,7 @@ and then start adding cool features like easy support for
 multi-account, auto-updates etc.
 
 ## Prerequisites
-* node >= v6.3.1
+* node >= v6.9.4
 > Use [nvm](https://github.com/creationix/nvm) to install the current stable version of node
 
 
@@ -21,6 +21,11 @@ multi-account, auto-updates etc.
 ```sh
 $ sudo apt-get install build-essential libxext-dev libxtst-dev libxkbfile-dev
 ```
+* If you're on Windows, you'll need to install following package as administrator:
+```sh
+C:\Windows\system32> npm install -g windows-build-tools
+```
+
 
 ## Installation
 


### PR DESCRIPTION
There was a missing installation instruction for Zulip-electron for Windows.
I faced errors everytime I tried to install in Windows.

This PR adds missing the instruction.
It would be great if I could include all instructions and improve the README.md
So, @timabbott @akashnimare @brainwane  any suggestions are welcome.