### PR TITLE
[WIP]#143 Improve handling of coming back online with the desktop app

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -347,6 +347,10 @@ app.on('ready', () => {
 			appUpdater();
 		}
 	});
+	electron.powerMonitor.on('resume', () => {
+		mainWindow.reload();
+		mainWindow.webContents.send('destroytray');
+         });
 	checkConnection();
 });
 

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -350,7 +350,7 @@ app.on('ready', () => {
 	electron.powerMonitor.on('resume', () => {
 		mainWindow.reload();
 		mainWindow.webContents.send('destroytray');
-         });
+	});
 	checkConnection();
 });
 


### PR DESCRIPTION
I have added the code to auto-reload app whenever the system is resumed from sleep.
The user now need not reload the app by himself. The app auto-reloads 🚀 

If on resuming the system. The Internet is not there, a dialog box appears showing Internet connectivity error and asking to "Try again", as we used to deal with no internet connection during app startup.


Further suggestions to improve the solution are welcome 😃 